### PR TITLE
Fix to check `jax.Array`-inheritance instead of `ndarray`.

### DIFF
--- a/bobbin/cron.py
+++ b/bobbin/cron.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from flax import struct
 from flax.training import checkpoints
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -158,14 +159,14 @@ class _ArrayEncoder(json.JSONEncoder):
     """Internal JSON encoder that supports array encoding."""
 
     def default(self, obj: Any):
-        if isinstance(obj, np.ndarray) or isinstance(obj, jnp.DeviceArray):
+        if isinstance(obj, (np.ndarray, jnp.DeviceArray, jax.Array)):
             if obj.shape == ():
                 # Scalar is serialized as normal scalar
                 return obj.tolist()
             return dict(
                 __array__=True,
                 dtype=obj.dtype.name,
-                data=obj.to_list(),
+                data=obj.tolist(),
             )
         return super().default(obj)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,5 @@ filterwarnings =
     ignore:No GPU/TPU found, falling back to CPU.*:UserWarning
 # Jax warns about XLA not being able to use donated buffers.
     ignore:Some donated buffers were not usable.*:UserWarning
+# Some deprecated features can be used internally by TF
+    ignore:`np.bool8` is a deprecated alias.*:DeprecationWarning

--- a/tests/cron_test.py
+++ b/tests/cron_test.py
@@ -14,16 +14,41 @@
 
 """Tests for cron."""
 
+import json
 import unittest
 
 from absl.testing import absltest
+from absl.testing import parameterized
 import chex
 import flax
+import jax.numpy as jnp
+import numpy as np
 import optax
 
 from bobbin import cron
 
 _FrozenDict = flax.core.FrozenDict
+
+
+class JsonEncoderTest(chex.TestCase):
+    @parameterized.named_parameters(
+        ("np_array", lambda x: np.asarray(x)), ("jnp_array", lambda x: jnp.asarray(x))
+    )
+    def test_array_serialization(self, asarray_fn):
+        # This test currently involves private features direcltly, and it
+        # should be avoided once we found a reasonable boundary between private/
+        # public APIs.'
+        x = asarray_fn(np.random.uniform(size=(3, 5)))
+        y = asarray_fn(np.random.uniform(size=(7,)))
+        z = asarray_fn(np.random.uniform(size=()))
+
+        # Note that tuples will be transformed to lists by serializer.
+        data = [dict(x=x, y=y), z]
+        json_data = json.dumps(data, cls=cron._ArrayEncoder)
+        reconstructed = json.loads(
+            json_data, object_hook=cron._json_object_hook_for_arrays
+        )
+        chex.assert_trees_all_equal(data, reconstructed)
 
 
 class TriggerTest(chex.TestCase):

--- a/tests/pmap_util_test.py
+++ b/tests/pmap_util_test.py
@@ -40,6 +40,9 @@ def noisy_linear(
 
 
 _N_CPU_DEVICES = 4
+chex.set_n_cpu_devices(
+    _N_CPU_DEVICES
+)  # Just for making sure it is done before any jax ops
 
 
 def setUpModule():


### PR DESCRIPTION
This CL also modifies "pytest.ini" to allow `DeprecationWarning` due to TF.