### PR TITLE
Fix `PaddedBatchNorm` in evalutaion mode.

### DIFF
--- a/bobbin/example_lib/asrnn.py
+++ b/bobbin/example_lib/asrnn.py
@@ -779,9 +779,11 @@ class PaddedBatchNorm(nn.Module):
                 axis_index_groups=self.axis_index_groups,
             )
 
-        if not self.is_initializing():
-            ra_mean.value = self.momentum * ra_mean.value + (1 - self.momentum) * mean
-            ra_var.value = self.momentum * ra_var.value + (1 - self.momentum) * var
+            if not self.is_initializing():
+                ra_mean.value = (
+                    self.momentum * ra_mean.value + (1 - self.momentum) * mean
+                )
+                ra_var.value = self.momentum * ra_var.value + (1 - self.momentum) * var
 
         results = _normalize(
             self,


### PR DESCRIPTION
The previous implementation attempts to update running average even when `use_running_average` is set.