### PR TITLE
Remove `isinstance` test with `chex.Array`.

### DIFF
--- a/bobbin/example_lib/asrnn.py
+++ b/bobbin/example_lib/asrnn.py
@@ -457,9 +457,9 @@ def _build_1d_masks(
     rng_for_loc, rng_for_width = jax.random.split(rng)
     if limits is None:
         limits = target_length
-    if not isinstance(limits, _Array):
+    if isinstance(limits, int):
         limits = jnp.full((batch_size,), limits, dtype=np.float32)
-    if not isinstance(widths, _Array):
+    if isinstance(widths, int):
         widths = jnp.full((batch_size,), widths, dtype=np.float32)
 
     limits -= widths

--- a/bobbin/var_util.py
+++ b/bobbin/var_util.py
@@ -167,7 +167,7 @@ def summarize_shape(tree: chex.ArrayTree) -> str:
                 ret += visit_node(v, indent_level + 1)
         return ret
 
-    if isinstance(tree, chex.Array):
+    if hasattr(tree, "shape") and hasattr(tree, "dtype"):
         return metadata_to_str(tree)
 
     # normalize


### PR DESCRIPTION
Python-3.7 doesn't support instance check with subscripted types. (Still it's unclear how this issue was invisible before.)