### PR TITLE
Changes to simplify main loop.

### DIFF
--- a/bobbin/cron.py
+++ b/bobbin/cron.py
@@ -391,13 +391,24 @@ class CronTab:
         self._actions.append((name, trigger, action))
         return self
 
-    def run(self, train_state: _TrainState, *args, **kwargs) -> Dict[str, Any]:
+    def run(
+        self,
+        train_state: _TrainState,
+        is_train_state_replicated: bool = True,
+        *args,
+        **kwargs,
+    ) -> Dict[str, Any]:
         """Checks triggers and run the corresponding actions if needed.
 
         Args:
           train_state: current training state.
+          is_train_state_replicated: if True (by default), `train_state` will be
+            unreplicated before given to actions.
           *args, **kwargs: extra parameters passed to the actions.
         """
+
+        if is_train_state_replicated:
+            train_state = flax.jax_utils.unreplicate(train_state)
         results = dict()
         for name, trig, act in self._actions:
             if trig.check(train_state):

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -166,10 +166,11 @@ class ClassificationTask(bobbin.TrainTask):
         *,
         extra_vars: _VarCollection,
         prng_key: chex.PRNGKey,
+        step: chex.Scalar,
     ) -> Tuple[chex.Scalar, Tuple[_VarCollection, LossAuxOut]]:
         inputs, labels = batch
         model_vars = extra_vars.copy()
-        model_vars.update(params=params, intermediates=dict())
+        model_vars.update(params=params, tensorboard=dict())
         logits, updated_vars = self.model.apply(
             model_vars,
             inputs,
@@ -311,9 +312,7 @@ def main(args: argparse.Namespace):
     for batch in train_ds.as_numpy_iterator():
         rng, prng_key = jax.random.split(prng_key)
         train_state, step_info = train_step_fn(train_state, batch, rng)
-        train_state_0 = flax.jax_utils.unreplicate(train_state)
-        crontab.run(train_state_0, step_info=step_info)
-        del train_state.extra_vars["tensorboard"]
+        crontab.run(train_state, step_info=step_info)
 
 
 if __name__ == "__main__":

--- a/tests/training_test.py
+++ b/tests/training_test.py
@@ -40,7 +40,7 @@ def l2_distortion_loss(params: chex.Array, x: chex.Array):
 
 
 class SgdMeanEstimation(training.TrainTask):
-    def compute_loss(self, params, batch, *, extra_vars, prng_key):
+    def compute_loss(self, params, batch, *, extra_vars, prng_key, step):
         # those are not used
         del extra_vars
         del prng_key


### PR DESCRIPTION
- `CronTab.run` now unreplicate trainin state.
- `compute_loss` in examples now clears tensorboard vars.
- `compute_loss` now takes `step` argument and learning-rate SoWs are now added in `compute_loss`.