### PR TITLE
Disable integrity test in initialization.

### DIFF
--- a/bobbin/training.py
+++ b/bobbin/training.py
@@ -37,7 +37,6 @@ import time
 
 from .array_util import split_leading_axis
 
-from .pmap_util import assert_replica_integrity
 from .pmap_util import tpmap
 
 from .tensorboard import publish_train_intermediates
@@ -488,8 +487,5 @@ def initialize_train_state(
 
     if checkpoint_path is not None and os.path.exists(checkpoint_path):
         new_state = checkpoints.restore_checkpoint(checkpoint_path, new_state)
-
-    if jax.process_count() > 1:
-        assert_replica_integrity(new_state, is_device_replicated=False)
 
     return new_state


### PR DESCRIPTION
This was problematic because it allocates huge amount of memory on TPUs. Therefore, we now use CPU as a default backend for integrity test, and also it is disabled by default.