### PR TITLE
Change to use `prod` instaed of deprecated `product`.

### DIFF
--- a/bobbin/example_lib/asrnn.py
+++ b/bobbin/example_lib/asrnn.py
@@ -660,7 +660,7 @@ class SpecAug(nn.Module):
                 self.freq_mask_count,
                 widths=self.freq_mask_max_bins,
             )
-            mask = jnp.product(mask, axis=-1)[:, np.newaxis, :]
+            mask = jnp.prod(mask, axis=-1)[:, np.newaxis, :]
             mask = mask.reshape(mask.shape + (1,) * len(channels))
             x = x * mask
         if self.time_mask_count > 0:
@@ -678,7 +678,7 @@ class SpecAug(nn.Module):
                 widths=widths,
                 limits=lengths,
             )
-            mask = jnp.product(mask, axis=-1)
+            mask = jnp.prod(mask, axis=-1)
             mask = mask.reshape(mask.shape + (1,) + (1,) * len(channels))
             x = x * mask
         return x

--- a/bobbin/var_util.py
+++ b/bobbin/var_util.py
@@ -136,7 +136,7 @@ def total_dimensionality(tree: ArrayTree) -> int:
         if arr is None:  # None is counted as zero
             return n
         else:
-            return n + np.product(np.asarray(arr).shape)
+            return n + np.prod(np.asarray(arr).shape)
 
     return jax.tree_util.tree_reduce(reduce, tree, 0)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,8 @@ filterwarnings =
     ignore:`np.bool8` is a deprecated alias.*:DeprecationWarning
 # Some deprecated features used internally in TF
     ignore:The distutils package is deprecated.*:DeprecationWarning
+# Some deprecated features used internally in TF
+    ignore:module 'sre_constants' is deprecated.*:DeprecationWarning
 # Some deprecated features used internally in Flax
     ignore:jax.experimental.pjit.PartitionSpec is deprecated.*:DeprecationWarning
     ignore:jax.experimental.maps.Mesh is deprecated.*:DeprecationWarning


### PR DESCRIPTION
This commit also modifies pytest.ini for ignoring a deprecation error.